### PR TITLE
fix splitting of cache-control header

### DIFF
--- a/caching.js
+++ b/caching.js
@@ -44,7 +44,7 @@ module.exports = function(uri, options, callback) {
       var private = false;
       if ('cache-control' in res.headers) {
         // In case of Cache-Control: no-cache, cacheable should remain false.
-        var val = res.headers['cache-control'].replace(/\s/,'').split(',');
+        var val = res.headers['cache-control'].split(/\s*,\s*/);
         var cacheControl = {};
         val.forEach(function(dir) {
           var arr = dir.split('=');


### PR DESCRIPTION
First of all, thanks for making this module.  It's exactly what I need to cache responses from service requests!   There is one small problem: 

The splitting of the cache-control header value is incorrect, only stripping the first space character before splitting on commas.  As a result, cache-control header values like this:

`cache-control: private, must-revalidate, max-age=0`

 results in cache-directive with spaces in their names:

`{'private': true, 'must-revalidate': true, ' max-age': '0'}`

which prevents correct interpretation of the response.
